### PR TITLE
Fix typing-extension dependencies according to Python version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -136,7 +136,7 @@ requests = ">=2.7.9"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -800,7 +800,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "f66f7a5551fa63c76cb781bbc56c0a1de50ce4b53258dec4eb8fd9fca1023f94"
+content-hash = "b34a6f2595df5e396a1772c97c787a71f30964513d9d299ec342d43654561505"
 lock-version = "1.0"
 python-versions = "^3.6.1"
 
@@ -982,7 +982,6 @@ mypy-extensions = [
 ]
 nodeenv = [
     {file = "nodeenv-1.4.0-py2.py3-none-any.whl", hash = "sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc"},
-    {file = "nodeenv-1.4.0.tar.gz", hash = "sha256:26941644654d8dd5378720e38f62a3bac5f9240811fb3b8913d2663a17baa91c"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 python = "^3.6.1"
 requests = "^2.24.0"
 pytz = "^2020.1"
-typing-extensions = {version = "^3.7.4", python = "~3.7 || ~3.6"}
+typing-extensions = {version = "^3.7.4", python = "~3.6 || ~3.7"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 python = "^3.6.1"
 requests = "^2.24.0"
 pytz = "^2020.1"
-typing-extensions = {version = "^3.7.4", python = "~3.7 || ~3.8"}
+typing-extensions = {version = "^3.7.4", python = "~3.7 || ~3.6"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.1"


### PR DESCRIPTION
The `typing-extension` dependency is used to add TypeDict class in Python 3.6 and 3.7. This class is available natively for Python >= 3.8

The setting in `pyproject.toml` was wrong. This PR correct it.