### PR TITLE
Switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,5 +70,5 @@ show_missing = true
 fail_under = 100
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
`poetry-core` is intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.

https://github.com/python-poetry/poetry-core 

From PRs on repositories:
- hacf-fr/freebox-api#187
- hacf-fr/synologydsm-api#84