### PR TITLE
Allow later pytz releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ Changelog = "https://github.com/hacf-fr/meteofrance-api/releases"
 python = "^3.6.1"
 requests = "^2.25.1"
 urllib3 = "^1.26.6"
-pytz = ">=2020.4,<2022.0"
+pytz = ">=2020.4,<2023.0"
 typing-extensions = {version = "^3.7.4", python = "~3.6 || ~3.7"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The latest [`pytz`](https://pypi.org/project/pytz/) is newer than the constraint.

Fixes #358