### PR TITLE
Allow any newer pytz version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ Changelog = "https://github.com/hacf-fr/meteofrance-api/releases"
 python = "^3.6.1"
 requests = "^2.25.1"
 urllib3 = "^1.26.6"
-pytz = ">=2020.4,<2023.0"
+pytz = ">=2020.4"
 typing-extensions = {version = "^3.7.4", python = "~3.6 || ~3.7"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Remove the upper bound for pytz releases. They use date version and it represents the version of the timezone database that it contains. It is safe to keep the upper bound.

It ends up conflicting with Home Assistant pytz version and pip is really strict nowadays.