### PR TITLE
Release 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meteofrance-api"
-version = "1.2.0"
+version = "1.3.0"
 description = "Python client for Météo-France API."
 authors = ["oncleben31 <oncleben31@gmail.com>", "quentame <polletquentin74@me.com>", "HACF <contact@hacf.fr>"]
 license = "MIT"


### PR DESCRIPTION
- Libs bump
- Bump Python version to 3.11 #561
- Drop Python 3.7 #648
- Fix 502 error on warning API #680 @faizpuru --> fixes https://github.com/hacf-fr/meteofrance-api/pull/680 & https://github.com/home-assistant/core/issues/92197
- Add warning dictionary API #682 @faizpuru
- Fix several security issues:
  - https://github.com/hacf-fr/meteofrance-api/security/dependabot/6 -> #620
  - https://github.com/hacf-fr/meteofrance-api/security/dependabot/7 -> #648
  - https://github.com/hacf-fr/meteofrance-api/security/dependabot/8 -> #643
  - https://github.com/hacf-fr/meteofrance-api/security/dependabot/10 -> #645
  - https://github.com/hacf-fr/meteofrance-api/security/dependabot/11 -> #648
  - https://github.com/hacf-fr/meteofrance-api/security/dependabot/12 -> #642
  - https://github.com/hacf-fr/meteofrance-api/security/dependabot/13 -> #645
  - https://github.com/hacf-fr/meteofrance-api/security/dependabot/16 -> #644

