### PR TITLE
Replace warning Inondation by Crues

### DIFF
--- a/src/meteofrance_api/const.py
+++ b/src/meteofrance_api/const.py
@@ -21,7 +21,7 @@ ALERT_TYPE_DICTIONARY_FR = {
     "1": "Vent violent",
     "2": "Pluie-inondation",
     "3": "Orages",
-    "4": "Inondation",
+    "4": "Crues",
     "5": "Neige-verglas",
     "6": "Canicule",
     "7": "Grand-froid",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -69,7 +69,7 @@ def test_readeable_phenomenoms_dict() -> None:
     ]
 
     expected_dictionary = {
-        "Inondation": "Vert",
+        "Crues": "Vert",
         "Neige-verglas": "Vert",
         "Pluie-inondation": "Vert",
         "Orages": "Jaune",


### PR DESCRIPTION
For example, for Orne (61) the library indicates Inondation and pluies inondation but Meteo France website shows Crues instead of Inondation.
