### PR TITLE
fix: typos dateime -> datetime

### DIFF
--- a/src/meteofrance_api/helpers.py
+++ b/src/meteofrance_api/helpers.py
@@ -161,7 +161,7 @@ def sort_places_versus_distance_from_coordinates(
     return sorted_places
 
 
-def timestamp_to_dateime_with_locale_tz(timestamp: int, local_tz: str) -> datetime:
+def timestamp_to_datetime_with_locale_tz(timestamp: int, local_tz: str) -> datetime:
     """Convert timestamp in datetime (Helper).
 
     Args:

--- a/src/meteofrance_api/model/forecast.py
+++ b/src/meteofrance_api/model/forecast.py
@@ -117,4 +117,6 @@ class Forecast:
             Datetime instance corresponding to the timestamp with the timezone of the
                 forecast location.
         """
-        return timestamp_to_datetime_with_locale_tz(timestamp, self.position["timezone"])
+        return timestamp_to_datetime_with_locale_tz(
+            timestamp, self.position["timezone"]
+        )

--- a/src/meteofrance_api/model/forecast.py
+++ b/src/meteofrance_api/model/forecast.py
@@ -8,7 +8,7 @@ from typing import TypedDict
 
 from pytz import utc
 
-from meteofrance_api.helpers import timestamp_to_dateime_with_locale_tz
+from meteofrance_api.helpers import timestamp_to_datetime_with_locale_tz
 
 
 class ForecastData(TypedDict, total=False):
@@ -117,4 +117,4 @@ class Forecast:
             Datetime instance corresponding to the timestamp with the timezone of the
                 forecast location.
         """
-        return timestamp_to_dateime_with_locale_tz(timestamp, self.position["timezone"])
+        return timestamp_to_datetime_with_locale_tz(timestamp, self.position["timezone"])

--- a/src/meteofrance_api/model/rain.py
+++ b/src/meteofrance_api/model/rain.py
@@ -96,4 +96,6 @@ class Rain:
             A datetime instance corresponding to the timestamp with the timezone of the
                 rain forecast location.
         """
-        return timestamp_to_datetime_with_locale_tz(timestamp, self.position["timezone"])
+        return timestamp_to_datetime_with_locale_tz(
+            timestamp, self.position["timezone"]
+        )

--- a/src/meteofrance_api/model/rain.py
+++ b/src/meteofrance_api/model/rain.py
@@ -7,7 +7,7 @@ from typing import List
 from typing import Optional
 from typing import TypedDict
 
-from meteofrance_api.helpers import timestamp_to_dateime_with_locale_tz
+from meteofrance_api.helpers import timestamp_to_datetime_with_locale_tz
 
 
 class RainData(TypedDict):
@@ -80,7 +80,7 @@ class Rain:
             # get the time stamp of the first cadran with rain
             next_rain_timestamp = next_rain["dt"]
             # convert timestamp in datetime with local timezone
-            next_rain_dt_local = timestamp_to_dateime_with_locale_tz(
+            next_rain_dt_local = timestamp_to_datetime_with_locale_tz(
                 next_rain_timestamp, self.position["timezone"]
             )
 
@@ -96,4 +96,4 @@ class Rain:
             A datetime instance corresponding to the timestamp with the timezone of the
                 rain forecast location.
         """
-        return timestamp_to_dateime_with_locale_tz(timestamp, self.position["timezone"])
+        return timestamp_to_datetime_with_locale_tz(timestamp, self.position["timezone"])


### PR DESCRIPTION
breaking change:
- `helper`: `timestamp_to_dateime_with_locale_tz` -> `timestamp_to_datetime_with_locale_tz`