### PR TITLE
fix: typos Warnning -> Warning

### DIFF
--- a/src/meteofrance_api/helpers.py
+++ b/src/meteofrance_api/helpers.py
@@ -42,7 +42,7 @@ def get_warning_text_status_from_indice_color(
 def get_phenomenon_name_from_indice(
     int_phenomenon: str, lang: str = "fr"
 ) -> Optional[str]:
-    """Convert the phenomenon code in readable text (Hepler).
+    """Convert the phenomenon code in readable text (Helper).
 
     Args:
         int_phenomenon: ID of the phenomenon in int. Value expected between 1 and 9.

--- a/src/meteofrance_api/model/warning.py
+++ b/src/meteofrance_api/model/warning.py
@@ -32,7 +32,7 @@ class PhenomenonMaxColor(TypedDict):
     phenomenon_max_color_id: int
 
 
-class WarnningCurrentPhenomenonsData(TypedDict):
+class WarningCurrentPhenomenonsData(TypedDict):
     """Describing the data structure of CurrentPhenomenons object from the REST API."""
 
     update_time: int
@@ -41,7 +41,7 @@ class WarnningCurrentPhenomenonsData(TypedDict):
     phenomenons_max_colors: List[PhenomenonMaxColor]
 
 
-class WarnningFullData(TypedDict):
+class WarningFullData(TypedDict):
     """Describing the data structure of full object from the REST API."""
 
     update_time: int
@@ -75,13 +75,13 @@ class CurrentPhenomenons:
             current alert level.
     """
 
-    def __init__(self, raw_data: WarnningCurrentPhenomenonsData) -> None:
+    def __init__(self, raw_data: WarningCurrentPhenomenonsData) -> None:
         """Initialize a CurrentPhenomenons object.
 
         Args:
             raw_data: A dictionary representing the JSON response from
                 'warning/currentPhenomenons' REST API request. The structure is
-                described by the WarnningCurrentPhenomenonsData class.
+                described by the WarningCurrentPhenomenonsData class.
         """
         self.raw_data = raw_data
 
@@ -157,12 +157,12 @@ class Full:
             phenomenons type.
     """
 
-    def __init__(self, raw_data: WarnningFullData) -> None:
+    def __init__(self, raw_data: WarningFullData) -> None:
         """Initialize a Full object.
 
         Args:
             raw_data: A dictionary representing the JSON response from'warning/full'
-                REST API request. The structure is described by the WarnningFullData
+                REST API request. The structure is described by the WarningFullData
                 class.
         """
         self.raw_data = raw_data


### PR DESCRIPTION
Breaking change:
- `warning` model: `WarnningCurrentPhenomenonsData` ->  `WarningCurrentPhenomenonsData`
- `warning` model: `WarnningFullData` -> `WarningFullData`