### PR TITLE
Bump actions/[upload|download]-artifact from v3 to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,10 +134,6 @@ jobs:
           pattern: coverage-data-*
           merge-multiple: true
 
-      - run: ls -R coverage-data
-
-      - run: ls -la
-
       - name: Combine coverage data and display human readable report
         run: |
           nox --force-color --session=coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,7 @@ jobs:
           nox --force-color --python=${{ matrix.python-version }}
 
       - run: ls -la
+        if: matrix.os != 'windows-latest'
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,9 +90,8 @@ jobs:
         if: always() && matrix.session == 'tests'
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.os }}-${{ matrix.python-version }}
           path: ".coverage.*"
-          overwrite: true
           include-hidden-files: true
           if-no-files-found: error
 
@@ -133,7 +132,9 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          path: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: Combine coverage data and display human readable report
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,10 +101,19 @@ jobs:
         with:
           name: docs
           path: docs/_build
+  merge:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: coverage-data
+          pattern: coverage-data-*
 
   coverage:
     runs-on: ubuntu-latest
-    needs: tests
+    needs: merge
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4.1.1
@@ -132,9 +141,7 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v4
         with:
-          path: coverage-data
-          pattern: coverage-data-*
-          merge-multiple: true
+          name: coverage-data
 
       - run: ls -R coverage-data
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,8 +93,9 @@ jobs:
         if: always() && matrix.session == 'tests'
         uses: actions/upload-artifact@v4.4.3
         with:
-          name: coverage-data-${{ matrix.os }}-${{ matrix.python-version }}
+          name: coverage-data
           path: ".coverage.*"
+          overwrite: true
           include-hidden-files: true
           if-no-files-found: error
 
@@ -137,8 +138,7 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v4.1.8
         with:
-          name: coverage-data-*
-          merge-multiple: true
+          name: coverage-data
 
       - name: Combine coverage data and display human readable report
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,9 +86,6 @@ jobs:
         run: |
           nox --force-color --python=${{ matrix.python-version }}
 
-      - run: ls -la
-        if: matrix.os != 'windows-latest'
-
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
         uses: actions/upload-artifact@v4.4.3
@@ -132,8 +129,6 @@ jobs:
         run: |
           pip install --constraint=.github/workflows/constraints.txt nox nox-poetry
           nox --version
-
-      - run: ls -la
 
       - name: Download coverage data
         uses: actions/download-artifact@v4.1.8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,14 +88,11 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: actions/upload-artifact@v3
-        # uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
-          # name: coverage-data-${{ matrix.os }}-${{ matrix.python-version }}
+          name: coverage-data-${{ matrix.python-version }}-${{ matrix.os }}
           path: ".coverage.*"
-          # include-hidden-files: true
-          # if-no-files-found: error
+          include-hidden-files: true
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
@@ -131,20 +128,11 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt nox nox-poetry
           nox --version
 
-      # - name: Merge coverage data
-      #   uses: actions/upload-artifact/merge@v4
-      #   with:
-      #     name: coverage-data
-      #     pattern: coverage-data-*
-
       - name: Download coverage data
-        uses: actions/download-artifact@v3
-        # uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-data
-          # path: coverage-data
-          # pattern: coverage-data-*
-          # merge-multiple: true
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - run: ls -R coverage-data
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,9 +86,11 @@ jobs:
         run: |
           nox --force-color --python=${{ matrix.python-version }}
 
+      - run: ls -R
+
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v4.4.3"
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: coverage-data
           path: ".coverage.*"
@@ -126,6 +128,8 @@ jobs:
         run: |
           pip install --constraint=.github/workflows/constraints.txt nox nox-poetry
           nox --version
+
+      - run: ls -R
 
       - name: Download coverage data
         uses: actions/download-artifact@v4.1.8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
         if: always() && matrix.session == 'tests'
         uses: actions/upload-artifact@v4.4.3
         with:
-          name: coverage-data
+          name: coverage-data-${{ env.MATRIX_ID }}
           path: ".coverage.*"
           include-hidden-files: true
           if-no-files-found: error
@@ -137,7 +137,8 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v4.1.8
         with:
-          name: coverage-data
+          name: coverage-data-*
+          merge-multiple: true
 
       - name: Combine coverage data and display human readable report
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,8 @@ jobs:
 
       - run: ls -la
         if: matrix.os != 'windows-latest'
+      
+      - run: "echo '### MATRIX_ID : ${{ env.MATRIX_ID }}'"
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,6 +136,10 @@ jobs:
           pattern: coverage-data-*
           merge-multiple: true
 
+      - run: ls -R coverage-data
+
+      - run: ls -la
+
       - name: Combine coverage data and display human readable report
         run: |
           nox --force-color --session=coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           nox --force-color --python=${{ matrix.python-version }}
 
-      - run: ls -R
+      - run: ls -la
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
@@ -129,7 +129,7 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt nox nox-poetry
           nox --version
 
-      - run: ls -R
+      - run: ls -la
 
       - name: Download coverage data
         uses: actions/download-artifact@v4.1.8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,14 +88,14 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v3.1.3"
+        uses: "actions/upload-artifact@v4.4.3"
         with:
           name: coverage-data
           path: ".coverage.*"
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: docs
           path: docs/_build
@@ -128,7 +128,7 @@ jobs:
           nox --version
 
       - name: Download coverage data
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: coverage-data
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,32 +88,25 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
+        # uses: actions/upload-artifact@v4
         with:
-          name: coverage-data-${{ matrix.os }}-${{ matrix.python-version }}
+          name: coverage-data
+          # name: coverage-data-${{ matrix.os }}-${{ matrix.python-version }}
           path: ".coverage.*"
-          include-hidden-files: true
-          if-no-files-found: error
+          # include-hidden-files: true
+          # if-no-files-found: error
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: docs
           path: docs/_build
-  merge:
-    runs-on: ubuntu-latest
-    needs: tests
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: coverage-data
-          pattern: coverage-data-*
 
   coverage:
     runs-on: ubuntu-latest
-    needs: merge
+    needs: tests
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4.1.1
@@ -138,10 +131,20 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt nox nox-poetry
           nox --version
 
+      # - name: Merge coverage data
+      #   uses: actions/upload-artifact/merge@v4
+      #   with:
+      #     name: coverage-data
+      #     pattern: coverage-data-*
+
       - name: Download coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
+        # uses: actions/download-artifact@v4
         with:
           name: coverage-data
+          # path: coverage-data
+          # pattern: coverage-data-*
+          # merge-multiple: true
 
       - run: ls -R coverage-data
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           name: coverage-data
           path: ".coverage.*"
+          include-hidden-files: true
           if-no-files-found: error
 
       - name: Upload documentation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,14 +88,12 @@ jobs:
 
       - run: ls -la
         if: matrix.os != 'windows-latest'
-      
-      - run: "echo '### MATRIX_ID : ${{ env.MATRIX_ID }}'"
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
         uses: actions/upload-artifact@v4.4.3
         with:
-          name: coverage-data-${{ env.MATRIX_ID }}
+          name: coverage-data-${{ matrix.os }}-${{ matrix.python-version }}
           path: ".coverage.*"
           include-hidden-files: true
           if-no-files-found: error

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           name: coverage-data
           path: ".coverage.*"
+          if-no-files-found: error
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-data
           path: ".coverage.*"
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build
@@ -131,7 +131,7 @@ jobs:
           nox --version
 
       - name: Download coverage data
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4
         with:
           name: coverage-data
 


### PR DESCRIPTION
Closes:
- #757
- #727

`upload-artifact` v4 release note: https://github.com/actions/upload-artifact/releases/tag/v4.0.0

Migration from v3 to v4: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md from https://github.com/actions/upload-artifact/issues/472

Issues:
- coverage reports can't be found by upload-artifact because they have different names, exemples:
  - Linus: `.coverage.fv-az1215-275.1825.XqJOxUvx`
  - Mac: `.coverage.Mac-1730043965740.local.2507.XbzhYwzx`
  - Windows: ?
- created multiple artifacts with the same name, that needs to either bu overridden or handled separately then merged
  - when override: got issue with parallel execution https://github.com/hacf-fr/meteofrance-api/actions/runs/11542330301/job/32125431180

Special thanks:
- https://github.com/hacf-fr/renault-api/pull/1116
- https://github.com/nedbat/coveragepy/blob/d7d133c26dcddfd76656bfc95b15d8a542506048/.github/workflows/coverage.yml
- https://github.com/dalito/ucumvert/blob/93cc94ddf2c01c4d2a209167a1cc53c87cc69551/.github/workflows/ci.yml
